### PR TITLE
Multipath: fix race when detaching devices

### DIFF
--- a/os_brick/initiator/linuxscsi.py
+++ b/os_brick/initiator/linuxscsi.py
@@ -19,6 +19,7 @@
 import os
 import re
 import six
+import time
 
 from oslo_concurrency import processutils as putils
 from oslo_log import log as logging
@@ -157,6 +158,7 @@ class LinuxSCSI(executor.Executor):
             LOG.debug("Flush multipath device %s", device)
             self._execute('multipath', '-f', device, run_as_root=True,
                           root_helper=self._root_helper)
+            time.sleep(1)
         except putils.ProcessExecutionError as exc:
             LOG.warning(_LW("multipath call failed exit %(code)s"),
                         {'code': exc.exit_code})


### PR DESCRIPTION
`multipath -f` can be racy and multipath/udev is not happy about that,
causing `systemd-udevd` to enter D-state.
This patch adds a 1 second sleep when detaching a LUN, thus avoiding
a race condition.
If using LVM, you might want to disable `use_lvmetad = 0` in your
lvm.conf.

The `systemd-udevd` D-state stack trace is similar to this one in a [Red Hat Bug 1173739](https://bugzilla.redhat.com/show_bug.cgi?id=1173739#c9), comment 9.

Signed-off-by: Rodrigo Freire <rbs@brasilia.br>