### PR TITLE
test-requirements: bump hacking version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking<0.11,>=0.10.0
+hacking<0.13,>=0.11.0
 coverage>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT
 python-subunit>=0.0.18 # Apache-2.0/BSD


### PR DESCRIPTION
hacking version 0.10.2 requires conflicting pbr 2.0
this issue was fixed in hacking 0.11